### PR TITLE
Revisioned `adb.py`

### DIFF
--- a/util/adb.py
+++ b/util/adb.py
@@ -29,7 +29,7 @@ class Adb(object):
         subprocess.call(cmd)
         #checking the emulator state
         cmd = ['adb', '-e', 'get-state']
-        process = subprocess.Popen(cmd, stdout = subprocess.PIPE, shell=True)
+        process = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True)
         #processing only the std_out data, if there is an error it will be sent to std_err,
         #so if the get-state fails ('error: no emulators found') => state=''
         state = process.communicate()[0].decode()


### PR DESCRIPTION
- Changed the `start-server` function: the `connect` command is now used only when necessary, since some emulators are automatically added to the adb daemon.
- Added the adb global option `-e`: this way if the daemon finds more than one device, but there is only one emulator, the script won't stop working due to a "more than one device" error.