### PR TITLE
Detection improvements and other fixes

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -15,6 +15,7 @@ BossFleet: False
 OilLimit: 1000
 RetireCycle: 2
 RetreatAfter: 0
+SmallBossIcon: False
 
 [Headquarters]
 Dorm: False

--- a/modules/combat.py
+++ b/modules/combat.py
@@ -18,7 +18,7 @@ class CombatModule(object):
         self.config = config
         self.stats = stats
         self.chapter_map = self.config.combat['map']
-
+        Utils.small_boss_icon = config.combat['small_boss_icon']
         self.exit = 0
         self.combats_done = 0
         self.l = []
@@ -412,7 +412,7 @@ class CombatModule(object):
             if self.exit != 0:
                 self.retreat_handler()
                 return True
-            if Utils.find("enemy/fleet_boss", 0.85, self.chapter_map):
+            if Utils.find_in_scaling_range("enemy/fleet_boss"):
                 Logger.log_msg("Boss fleet was found.")
 
                 if self.config.combat['boss_fleet']:
@@ -426,19 +426,19 @@ class CombatModule(object):
 
                     Utils.touch_randomly(self.region['button_switch_fleet'])
                     Utils.wait_update_screen(2)
-                    boss_region = Utils.find("enemy/fleet_boss", 0.9, self.chapter_map)
+                    boss_region = Utils.find_in_scaling_range("enemy/fleet_boss")
 
                     while not boss_region:
                         if s > 3: s = 0
                         swipes.get(s)()
 
                         Utils.wait_update_screen(0.5)
-                        boss_region = Utils.find("enemy/fleet_boss", 0.85, self.chapter_map)
+                        boss_region = Utils.find_in_scaling_range("enemy/fleet_boss")
                         s += 1
                     Utils.swipe(boss_region.x, boss_region.y, 960, 540, 300)
                     Utils.wait_update_screen()
 
-                boss_region = Utils.find("enemy/fleet_boss", 0.9, self.chapter_map)
+                boss_region = Utils.find_in_scaling_range("enemy/fleet_boss")
                 #extrapolates boss_info(x,y,enemy_type) from the boss_region found
                 boss_info = [boss_region.x + 50, boss_region.y + 25, "boss"]
                 self.clear_boss(boss_info)

--- a/modules/combat.py
+++ b/modules/combat.py
@@ -512,17 +512,17 @@ class CombatModule(object):
                 i += 1
             Utils.update_screen()
 
-            l1 = filter(lambda x:x[1] > 160 and x[1] < 977 and x[0] > 180, map(lambda x:[x[0] - 3, x[1] - 45], Utils.find_all('enemy/fleet_level', sim - 0.15, self.chapter_map)))
+            l1 = filter(lambda x:x[1] > 160 and x[1] < 938 and x[0] > 180 and x[0] < 1790, map(lambda x:[x[0] - 3, x[1] - 45], Utils.find_all('enemy/fleet_level', sim - 0.15)))
             l1 = [x for x in l1 if (not self.filter_blacklist(x, blacklist))]
-            l2 = filter(lambda x:x[1] > 160 and x[1] < 977 and x[0] > 180, map(lambda x:[x[0] + 75, x[1] + 110], Utils.find_all('enemy/fleet_1_down', sim, self.chapter_map)))
+            l2 = filter(lambda x:x[1] > 160 and x[1] < 938 and x[0] > 180 and x[0] < 1790, map(lambda x:[x[0] + 75, x[1] + 110], Utils.find_all('enemy/fleet_1_down', sim)))
             l2 = [x for x in l2 if (not self.filter_blacklist(x, blacklist))]
-            l3 = filter(lambda x:x[1] > 160 and x[1] < 977 and x[0] > 180, map(lambda x:[x[0] + 75, x[1] + 110], Utils.find_all('enemy/fleet_2_down', sim - 0.02, self.chapter_map)))
+            l3 = filter(lambda x:x[1] > 160 and x[1] < 938 and x[0] > 180 and x[0] < 1790, map(lambda x:[x[0] + 75, x[1] + 110], Utils.find_all('enemy/fleet_2_down', sim - 0.02)))
             l3 = [x for x in l3 if (not self.filter_blacklist(x, blacklist))]
-            l4 = filter(lambda x:x[1] > 160 and x[1] < 977 and x[0] > 180, map(lambda x:[x[0] + 75, x[1] + 130], Utils.find_all('enemy/fleet_3_up', sim - 0.06, self.chapter_map)))
+            l4 = filter(lambda x:x[1] > 160 and x[1] < 938 and x[0] > 180 and x[0] < 1790, map(lambda x:[x[0] + 75, x[1] + 130], Utils.find_all('enemy/fleet_3_up', sim - 0.06)))
             l4 = [x for x in l4 if (not self.filter_blacklist(x, blacklist))]
-            l5 = filter(lambda x:x[1] > 160 and x[1] < 977 and x[0] > 180, map(lambda x:[x[0] + 75, x[1] + 110], Utils.find_all('enemy/fleet_3_down', sim - 0.06, self.chapter_map)))
+            l5 = filter(lambda x:x[1] > 160 and x[1] < 938 and x[0] > 180 and x[0] < 1790, map(lambda x:[x[0] + 75, x[1] + 110], Utils.find_all('enemy/fleet_3_down', sim - 0.06)))
             l5 = [x for x in l5 if (not self.filter_blacklist(x, blacklist))]
-            l6 = filter(lambda x:x[1] > 160 and x[1] < 977 and x[0] > 180, map(lambda x:[x[0] + 75, x[1] + 110], Utils.find_all('enemy/fleet_2_up', sim - 0.06, self.chapter_map)))
+            l6 = filter(lambda x:x[1] > 160 and x[1] < 938 and x[0] > 180 and x[0] < 1790, map(lambda x:[x[0] + 75, x[1] + 110], Utils.find_all('enemy/fleet_2_up', sim - 0.06)))
             l6 = [x for x in l6 if (not self.filter_blacklist(x, blacklist))]
 
             self.l = l1 + l2 + l3 + l4 + l5 + l6
@@ -605,7 +605,7 @@ class CombatModule(object):
                 while mystery_nodes == []:
                     Utils.update_screen()
 
-                    l1 = filter(lambda x:x[1] > 80 and x[1] < 977 and x[0] > 180, map(lambda x:[x[0], x[1] + 140], Utils.find_all('combat/question_mark', sim)))
+                    l1 = filter(lambda x:x[1] > 80 and x[1] < 938 and x[0] > 180 and x[0] < 1790, map(lambda x:[x[0], x[1] + 140], Utils.find_all('combat/question_mark', sim)))
                     l1 = [x for x in l1 if (not self.filter_blacklist(x, blacklist))]
 
                     mystery_nodes = l1

--- a/modules/commission.py
+++ b/modules/commission.py
@@ -59,6 +59,8 @@ class CommissionModule(object):
                 while not Utils.find("menu/commission"):
                     Utils.touch_randomly(self.region["button_go"])
                     Utils.wait_update_screen(1)
+                    if Utils.find_and_touch("menu/alert_close"):
+                        Utils.script_sleep(1)
 
                 if self.urgent_handler():
                     self.daily_handler()

--- a/modules/enhancement.py
+++ b/modules/enhancement.py
@@ -51,6 +51,9 @@ class EnhancementModule(object):
                 if Utils.find("menu/dock"):
                     Utils.touch_randomly(self.region['button_favorite'])
                     continue
+                else:
+                    Utils.touch_randomly(self.region['button_go_back'])
+                    Utils.script_sleep(2)
 
     def enhance_ship(self):
         """

--- a/modules/event.py
+++ b/modules/event.py
@@ -55,7 +55,7 @@ class EventModule(object):
 
             while ('EX' in self.levels):
                 Utils.wait_update_screen(1)
-                if Utils.find(f"event/{event}/ex_completed", 0.98):
+                if Utils.find(f"event/{event}/ex_completed", 0.99):
                     Logger.log_info("No more EX combats to do.")
                     break
 

--- a/util/config.py
+++ b/util/config.py
@@ -92,6 +92,7 @@ class Config(object):
         self.combat['oil_limit'] = int(config.get('Combat', 'OilLimit'))
         self.combat['retire_cycle'] = config.get('Combat', 'RetireCycle')
         self.combat['retreat_after'] = int(config.get('Combat', 'RetreatAfter'))
+        self.combat['small_boss_icon'] = config.getboolean('Combat', 'SmallBossIcon')
 
     def _read_headquarters(self, config):
         """Method to parse the Headquarters settings passed in config.
@@ -169,6 +170,10 @@ class Config(object):
             if not isinstance(self.combat['oil_limit'], int):
                 self.ok = False
                 Logger.log_error("Oil limit must be an integer.")
+
+            if map[0] != "E" and self.combat['small_boss_icon']:
+                self.ok = False
+                Logger.log_error("Story maps don't have small boss icon.")
 
         if self.events['enabled']:
             events = ['Crosswave', 'Royal_Maids']

--- a/util/utils.py
+++ b/util/utils.py
@@ -31,6 +31,7 @@ last_ocr = ''
 
 class Utils(object):
 
+    small_boss_icon = False
     DEFAULT_SIMILARITY = 0.95
     assets = ''
     locations = ()
@@ -174,7 +175,7 @@ class Utils(object):
         return
 
     @classmethod
-    def find(cls, image, similarity=DEFAULT_SIMILARITY, cmap=None):
+    def find(cls, image, similarity=DEFAULT_SIMILARITY):
         """Finds the specified image on the screen
 
         Args:
@@ -186,17 +187,93 @@ class Utils(object):
             Region: region object containing the location and size of the image
         """
         template = cv2.imread('assets/{}/{}.png'.format(cls.assets, image), 0)
-        if cmap != None:
-            if cmap == '7-1':
-                template = cv2.resize(template, None, fx = 1.11, fy = 1.11, interpolation = cv2.INTER_NEAREST)
-            if (cmap == 'E-B3' or cmap == 'E-D3') and image == 'enemy/fleet_boss':
-                template = cv2.resize(template, None, fx = 0.49, fy = 0.49, interpolation = cv2.INTER_NEAREST)
         width, height = template.shape[::-1]
         match = cv2.matchTemplate(screen, template, cv2.TM_CCOEFF_NORMED)
         value, location = cv2.minMaxLoc(match)[1], cv2.minMaxLoc(match)[3]
         if (value >= similarity):
             return Region(location[0], location[1], width, height)
         return None
+
+    @classmethod
+    def find_in_scaling_range(cls, image, similarity=DEFAULT_SIMILARITY, lowerEnd=0.8, upperEnd=1.2):
+        """Finds the location of the image on the screen. First the image is searched at its default scale,
+        and if it isn't found, it will be resized using values inside the range provided until a match that satisfy
+        the similarity value is found. If the image isn't found even after it has been resized, the method returns None.
+
+        Args:
+            image (string): Name of the image.
+            similarity (float, optional): Defaults to DEFAULT_SIMILARITY.
+                Percentage in similarity that the image should at least match
+            lowerEnd (float, optional): Defaults to 0.8.
+                Lowest scaling factor used for resizing.
+            upperEnd (float, optional): Defaults to 1.2.
+                Highest scaling factor used for resizing.
+
+        Returns:
+            Region: Coordinates or where the image appears.
+        """
+        template = cv2.imread('assets/{}/{}.png'.format(cls.assets, image), 0)
+        # first try with default size
+        width, height = template.shape[::-1]
+        match = cv2.matchTemplate(screen, template, cv2.TM_CCOEFF_NORMED)
+        value, location = cv2.minMaxLoc(match)[1], cv2.minMaxLoc(match)[3]
+        if (value >= similarity):
+            return Region(location[0], location[1], width, height)
+
+        # resize and match using threads
+
+        # change scaling factor if the boss icon searched is small
+        # (some events has as boss fleet a shipgirl with a small boss icon at her bottom right)
+        if cls.small_boss_icon and image == 'enemy/fleet_boss':
+            lowerEnd = 0.4
+            upperEnd = 0.6
+
+        # preparing interpolation methods        
+        middle_range = (upperEnd + lowerEnd)/2.0
+        if lowerEnd < 1 and upperEnd > 1 and middle_range == 1:
+            l_interpolation = cv2.INTER_AREA
+            u_interpolation = cv2.INTER_CUBIC
+        elif upperEnd < 1 and lowerEnd < upperEnd:
+            l_interpolation = cv2.INTER_AREA
+            u_interpolation = cv2.INTER_AREA
+        elif lowerEnd > 1 and upperEnd > lowerEnd:
+            l_interpolation = cv2.INTER_CUBIC
+            u_interpolation = cv2.INTER_CUBIC
+        else:
+            l_interpolation = cv2.INTER_NEAREST
+            u_interpolation = cv2.INTER_NEAREST
+
+        results_list = []
+        regions_detected = []
+        count = 0
+        loop_limiter = (middle_range - lowerEnd)*100
+
+        # creating and launching worker processes
+        pool = ThreadPool(processes=4)
+
+        while (upperEnd > lowerEnd) and (count < loop_limiter):
+            l_result = pool.apply_async(cls.resize_and_match, (template, lowerEnd, similarity, l_interpolation))
+            u_result = pool.apply_async(cls.resize_and_match, (template, upperEnd, similarity, u_interpolation))
+            cls.script_sleep(0.01)
+            lowerEnd+=0.02
+            upperEnd-=0.02
+            count +=1
+            results_list.append(l_result)
+            results_list.append(u_result)
+        
+        # closing pool and waiting for results
+        pool.close()
+        pool.join()
+
+        # extract regions from async_result
+        for i in range(0, len(results_list)):
+            if results_list[i].get() is not None:
+                regions_detected.append(results_list[i].get())
+
+        if (len(regions_detected)>0):
+            return regions_detected[0]
+        else:
+            return None
 
     @classmethod
     def find_all(cls, image, similarity=DEFAULT_SIMILARITY):
@@ -243,6 +320,15 @@ class Utils(object):
         template_resize = cv2.resize(image, None, fx = scale, fy = scale, interpolation = cv2.INTER_NEAREST)
         match_resize = cv2.matchTemplate(screen, template_resize, cv2.TM_CCOEFF_NORMED)
         return numpy.where(match_resize >= similarity)
+
+    @classmethod
+    def resize_and_match(cls, templateImage, scale, similarity=DEFAULT_SIMILARITY, interpolationMethod=cv2.INTER_NEAREST):
+        template_resize = cv2.resize(templateImage, None, fx = scale, fy = scale, interpolation = interpolationMethod)
+        width, height = template_resize.shape[::-1]
+        match = cv2.matchTemplate(screen, template_resize, cv2.TM_CCOEFF_NORMED)
+        value, location = cv2.minMaxLoc(match)[1], cv2.minMaxLoc(match)[3]
+        if (value >= similarity):
+             return Region(location[0], location[1], width, height)
 
     @classmethod
     def touch(cls, coords):


### PR DESCRIPTION
Small fixes and adjustments:
- Fixed commission module getting stuck after tapping an item received and then opening its info prompt.
- Improved reliability of the enhancement module.
- Increased similarity required for ex_completed event asset.  

Improved detection of enemy mobs:
- Added another filter for the x coordinate.
- Fixed multithreaded enemy search of find_all method and its related match_resize method.  

New find function and more generalized method for detecting boss fleet:
- Added find_in_scaling_range function: it makes use of resizing and threads to better locate the asset desired.
- Boss fleet detection now uses the new find_in_scaling_range function, more resistant to maps' zoom in/out.
- Added new SmallBossIcon setting: used for event maps where the boss fleet is a shipgirl.  

What could be further improved:
The `find_in_scaling_range` method is called a lot (at least once every loop cycle inside `clear_map`) and that is a bit wasteful; since the boss spawns after a certain number of kills, it would be wise to implement a counter and put it in short circuit `and` with said method, limiting the number of times the latter is executed.