### PR TITLE
Added support for detecting and attacking Siren Elites.

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -16,6 +16,7 @@ OilLimit: 1000
 RetireCycle: 2
 RetreatAfter: 0
 SmallBossIcon: False
+SirenElites: False
 
 [Headquarters]
 Dorm: False

--- a/modules/combat.py
+++ b/modules/combat.py
@@ -527,6 +527,12 @@ class CombatModule(object):
             l6 = [x for x in l6 if (not self.filter_blacklist(x, blacklist))]
 
             self.l = l1 + l2 + l3 + l4 + l5 + l6
+
+            if self.config.combat['siren_elites']:
+                l7 = Utils.find_enemies()
+                l7 = [x for x in l7 if (not self.filter_blacklist(x, blacklist))]
+                self.l += l7
+			
             sim -= 0.005
 
         self.l = Utils.filter_similar_coords(self.l)

--- a/modules/combat.py
+++ b/modules/combat.py
@@ -526,12 +526,12 @@ class CombatModule(object):
             l6 = filter(lambda x:x[1] > 160 and x[1] < 938 and x[0] > 180 and x[0] < 1790, map(lambda x:[x[0] + 75, x[1] + 110], Utils.find_all('enemy/fleet_2_up', sim - 0.06)))
             l6 = [x for x in l6 if (not self.filter_blacklist(x, blacklist))]
 
-            self.l = l1 + l2 + l3 + l4 + l5 + l6
-
             if self.config.combat['siren_elites']:
-                l7 = Utils.find_enemies()
+                l7 = Utils.find_siren_elites()
                 l7 = [x for x in l7 if (not self.filter_blacklist(x, blacklist))]
-                self.l += l7
+                self.l = l1 + l2 + l3 + l4 + l5 + l6 + l7
+            else:
+                self.l = l1 + l2 + l3 + l4 + l5 + l6
 			
             sim -= 0.005
 

--- a/util/config.py
+++ b/util/config.py
@@ -93,6 +93,7 @@ class Config(object):
         self.combat['retire_cycle'] = config.get('Combat', 'RetireCycle')
         self.combat['retreat_after'] = int(config.get('Combat', 'RetreatAfter'))
         self.combat['small_boss_icon'] = config.getboolean('Combat', 'SmallBossIcon')
+        self.combat['siren_elites'] = config.getboolean('Combat', 'SirenElites')
 
     def _read_headquarters(self, config):
         """Method to parse the Headquarters settings passed in config.


### PR DESCRIPTION
Changes:
- Implemented support for detecting/targeting Siren elites.
- Added a flag to enable/disable searching. Defaults to `false`.

Normally it's hard to get a match on the Sirens because they're animated along with the glowing red target box underneath them. However, I noticed the outer box of red stays the same - the only problem is that a straight line matched on too many things. I worked around this by taking the bottom half of the box, editing out the "glowing" part, and adding a transparency. This seems to let OpenCV match on the sirens properly.

We'll see for future events if this continues to work. If the Siren is too large and covers up the red box you may need to tweak the image it searches for. Seems transparency is a good way to selectively target static images if there's parts of it that are also animated.