### PR TITLE
Introduced a counter for battles before enemy boss appears and other adjustments

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -11,6 +11,7 @@ Server: EN
 [Combat]
 Enabled: False
 Map: 3-4
+KillsBeforeBoss: 0
 BossFleet: False
 OilLimit: 1000
 RetireCycle: 2

--- a/modules/combat.py
+++ b/modules/combat.py
@@ -77,6 +77,8 @@ class CombatModule(object):
             'menu_nav_back': Region(54, 57, 67, 67)
         }
 
+        self.swipe_counter = 0
+
     def combat_logic_wrapper(self):
         """Method that fires off the necessary child methods that encapsulates
         the entire action of sortieing combat fleets and resolving combat.
@@ -89,6 +91,7 @@ class CombatModule(object):
         self.kills_count = 0
         self.l.clear()
         self.blacklist.clear()
+        self.swipe_counter = 0
 
         while True:
             Utils.wait_update_screen()
@@ -535,42 +538,41 @@ class CombatModule(object):
 
     def get_enemies(self, blacklist=[], boss=False):
         sim = 0.99
-        i = 0
         if blacklist:
             Logger.log_info('Blacklist: ' + str(blacklist))
             if len(blacklist) > 2:
                 self.l.clear()
 
         while not self.l:
-            if (boss and len(blacklist) > 4) or (not boss and len(blacklist) > 3) or sim < 0.95:
-                if i > 3: i = 0
+            if (boss and len(blacklist) > 4) or (not boss and len(blacklist) > 3) or sim < 0.97:
+                if self.swipe_counter > 3: self.swipe_counter = 0
                 swipes = {
                     0: lambda: Utils.swipe(960, 240, 960, 940, 300),
                     1: lambda: Utils.swipe(1560, 540, 260, 540, 300),
                     2: lambda: Utils.swipe(960, 940, 960, 240, 300),
                     3: lambda: Utils.swipe(260, 540, 1560, 540, 300)
                 }
-                swipes.get(i)()
+                swipes.get(self.swipe_counter)()
                 sim += 0.005
-                i += 1
+                self.swipe_counter += 1
             Utils.update_screen()
 
-            l1 = filter(lambda x:(x[1] > 242 and x[1] < 1070 and x[0] > 180 and x[0] < 955) or (x[1] > 160 and x[1] < 938 and x[0] > 550 and x[0] < 1790), map(lambda x:[x[0] - 3, x[1] - 27], Utils.find_all('enemy/fleet_level', sim - 0.035, useMask=True)))
+            l1 = filter(lambda x:(x[1] > 242 and x[1] < 1070 and x[0] > 180 and x[0] < 955) or (x[1] > 160 and x[1] < 938 and x[0] > 550 and x[0] < 1790), map(lambda x:[x[0] - 3, x[1] - 27], Utils.find_all('enemy/fleet_level', sim - 0.025, useMask=True)))
             l1 = [x for x in l1 if (not self.filter_blacklist(x, blacklist))]
             Logger.log_debug("L1: " +str(l1))
-            l2 = filter(lambda x:(x[1] > 242 and x[1] < 1070 and x[0] > 180 and x[0] < 955) or (x[1] > 160 and x[1] < 938 and x[0] > 550 and x[0] < 1790), map(lambda x:[x[0] + 75, x[1] + 110], Utils.find_all('enemy/fleet_1_down', sim)))
+            l2 = filter(lambda x:(x[1] > 242 and x[1] < 1070 and x[0] > 180 and x[0] < 955) or (x[1] > 160 and x[1] < 938 and x[0] > 550 and x[0] < 1790), map(lambda x:[x[0] + 75, x[1] + 110], Utils.find_all('enemy/fleet_1_down', sim - 0.02)))
             l2 = [x for x in l2 if (not self.filter_blacklist(x, blacklist))]
             Logger.log_debug("L2: " +str(l2))
             l3 = filter(lambda x:(x[1] > 242 and x[1] < 1070 and x[0] > 180 and x[0] < 955) or (x[1] > 160 and x[1] < 938 and x[0] > 550 and x[0] < 1790), map(lambda x:[x[0] + 75, x[1] + 90], Utils.find_all('enemy/fleet_2_down', sim - 0.02)))
             l3 = [x for x in l3 if (not self.filter_blacklist(x, blacklist))]
             Logger.log_debug("L3: " +str(l3))
-            l4 = filter(lambda x:(x[1] > 242 and x[1] < 1070 and x[0] > 180 and x[0] < 955) or (x[1] > 160 and x[1] < 938 and x[0] > 550 and x[0] < 1790), map(lambda x:[x[0] + 75, x[1] + 125], Utils.find_all('enemy/fleet_3_up', sim - 0.06)))
+            l4 = filter(lambda x:(x[1] > 242 and x[1] < 1070 and x[0] > 180 and x[0] < 955) or (x[1] > 160 and x[1] < 938 and x[0] > 550 and x[0] < 1790), map(lambda x:[x[0] + 75, x[1] + 125], Utils.find_all('enemy/fleet_3_up', sim - 0.035)))
             l4 = [x for x in l4 if (not self.filter_blacklist(x, blacklist))]
             Logger.log_debug("L4: " +str(l4))
-            l5 = filter(lambda x:(x[1] > 242 and x[1] < 1070 and x[0] > 180 and x[0] < 955) or (x[1] > 160 and x[1] < 938 and x[0] > 550 and x[0] < 1790), map(lambda x:[x[0] + 75, x[1] + 100], Utils.find_all('enemy/fleet_3_down', sim - 0.06)))
+            l5 = filter(lambda x:(x[1] > 242 and x[1] < 1070 and x[0] > 180 and x[0] < 955) or (x[1] > 160 and x[1] < 938 and x[0] > 550 and x[0] < 1790), map(lambda x:[x[0] + 75, x[1] + 100], Utils.find_all('enemy/fleet_3_down', sim - 0.035)))
             l5 = [x for x in l5 if (not self.filter_blacklist(x, blacklist))]
             Logger.log_debug("L5: " +str(l5))
-            l6 = filter(lambda x:(x[1] > 242 and x[1] < 1070 and x[0] > 180 and x[0] < 955) or (x[1] > 160 and x[1] < 938 and x[0] > 550 and x[0] < 1790), map(lambda x:[x[0] + 75, x[1] + 110], Utils.find_all('enemy/fleet_2_up', sim - 0.04)))
+            l6 = filter(lambda x:(x[1] > 242 and x[1] < 1070 and x[0] > 180 and x[0] < 955) or (x[1] > 160 and x[1] < 938 and x[0] > 550 and x[0] < 1790), map(lambda x:[x[0] + 75, x[1] + 110], Utils.find_all('enemy/fleet_2_up', sim - 0.025)))
             l6 = [x for x in l6 if (not self.filter_blacklist(x, blacklist))]
             Logger.log_debug("L6: " +str(l6))
 

--- a/modules/combat.py
+++ b/modules/combat.py
@@ -25,6 +25,30 @@ class CombatModule(object):
         self.blacklist = []
         self.movement_event = {}
 
+        self.kills_count = 0
+        self.kills_before_boss = {
+            '1-1': 1, '1-2': 2, '1-3': 2, '1-4': 3,
+            '2-1': 2, '2-2': 3, '2-3': 3, '2-4': 3,
+            '3-1': 3, '3-2': 3, '3-3': 3, '3-4': 3,
+            '4-1': 3, '4-2': 3, '4-3': 3, '4-4': 4,
+            '5-1': 4, '5-2': 4, '5-3': 4, '5-4': 4,
+            '6-1': 4, '6-2': 4, '6-3': 4, '6-4': 5,
+            '7-1': 5, '7-2': 5, '7-3': 5, '7-4': 5,
+            '8-1': 4, '8-2': 4, '8-3': 4, '8-4': 4,
+            '9-1': 5, '9-2': 5, '9-3': 5, '9-4': 5,
+            '10-1': 6, '10-2': 6, '10-3': 6, '10-4': 6,
+            '11-1': 6, '11-2': 6, '11-3': 6, '11-4': 6,
+            '12-1': 6, '12-2': 6, '12-3': 6, '12-4': 6,
+            '13-1': 6, '13-2': 6, '13-3': 6, '13-4': 7
+        }
+        if self.chapter_map not in self.kills_before_boss:
+            # check if current map is present in the dictionary and if it isn't,
+            # a new entry is added with kills_before_boss value
+            self.kills_before_boss[self.chapter_map] = self.config.combat['kills_before_boss']
+        elif self.config.combat['kills_before_boss'] != 0:
+            # updates default value with the one provided by the user
+            self.kills_before_boss[self.chapter_map] = self.config.combat['kills_before_boss']
+
         self.region = {
             'fleet_lock': Region(1790, 750, 130, 30),
             'open_strategy_menu': Region(1797, 617, 105, 90),
@@ -62,6 +86,7 @@ class CombatModule(object):
         """
         self.exit = 0
         self.combats_done = 0
+        self.kills_count = 0
         self.l.clear()
         self.blacklist.clear()
 
@@ -226,6 +251,7 @@ class CombatModule(object):
                 continue
             if Utils.find("combat/button_confirm"):
                 Logger.log_msg("Combat ended.")
+                self.kills_count += 1
                 Utils.touch_randomly(self.region["combat_end_confirm"])
                 Utils.script_sleep(1)
                 if boss:
@@ -278,6 +304,7 @@ class CombatModule(object):
                 continue
             if event["combat/alert_failed_evade"]:
                 Logger.log_warning("Failed to evade ambush.")
+                self.kills_count -= 1
                 Utils.touch_randomly(self.region["menu_combat_start"])
                 self.battle_handler()
                 continue
@@ -427,7 +454,7 @@ class CombatModule(object):
             if self.exit != 0:
                 self.retreat_handler()
                 return True
-            if Utils.find_in_scaling_range("enemy/fleet_boss"):
+            if self.kills_count >= self.kills_before_boss[self.chapter_map] and Utils.find_in_scaling_range("enemy/fleet_boss"):
                 Logger.log_msg("Boss fleet was found.")
 
                 if self.config.combat['boss_fleet']:

--- a/util/config.py
+++ b/util/config.py
@@ -98,6 +98,7 @@ class Config(object):
         """
         self.combat['enabled'] = True
         self.combat['map'] = config.get('Combat', 'Map')
+        self.combat['kills_before_boss'] = int(config.get('Combat', 'KillsBeforeBoss'))
         self.combat['boss_fleet'] = config.getboolean('Combat', 'BossFleet')
         self.combat['oil_limit'] = int(config.get('Combat', 'OilLimit'))
         self.combat['retire_cycle'] = int(config.get('Combat', 'RetireCycle'))
@@ -190,6 +191,10 @@ class Config(object):
             if map[0] != "E" and self.combat['siren_elites']:
                 self.ok = False
                 Logger.log_error("Story maps don't have elite units.")
+
+            if not isinstance(self.combat['kills_before_boss'], int) or self.combat['kills_before_boss'] < 0:
+                self.ok = False
+                Logger.log_error("Invalid KillsBeforeBoss value: must be an integer >= 0.")
 
             if map[0] != "E" and self.combat['small_boss_icon']:
                 self.ok = False


### PR DESCRIPTION
Changes:
- Added a kills' counter which disables the search for boss fleet until the requirements (either specified by the user or a default setting) are met.
- Changed a condition that triggers the swiping search for enemies.
- Added an instance variable to keep track of the previous swipes done.
- Adjusted some similarity values to prevent false positives.