### PR TITLE
Fixing retirement checks

### DIFF
--- a/modules/retirement.py
+++ b/modules/retirement.py
@@ -84,33 +84,42 @@ class RetirementModule(object):
     def set_sort(self):
         Logger.log_debug("Retirement: " + repr(self.config.retirement))
         while not self.sorted:
-            Utils.update_screen()
-            if Utils.find("retirement/selected_none"):
-                Logger.log_debug("Retirement: Opening sorting menu.")
-                Utils.touch_randomly(self.region['sort_filters_button'])
-                Utils.script_sleep(0.5)
-                # Touch the All button to clear any current filter
-                Utils.touch_randomly(self.region['all_ship_filter'])
-                Utils.script_sleep(0.5)
-                if self.config.retirement['commons']:
-                    Utils.touch_randomly(self.region['common_ship_filter'])
-                    Utils.script_sleep(0.5)
-                if self.config.retirement['rares']:
-                    Utils.touch_randomly(self.region['rare_ship_filter'])
-                    Utils.script_sleep(0.5)
-                continue
-            if self.config.retirement['commons'] and not Utils.find("retirement/button_sort_common", 0.99):
-                Logger.log_debug("Retirement: Sorting commons")
+            Logger.log_debug("Retirement: Opening sorting menu.")
+            Utils.touch_randomly(self.region['sort_filters_button'])
+            Utils.script_sleep(0.5)
+            # Touch the All button to clear any current filter
+            Utils.touch_randomly(self.region['all_ship_filter'])
+            Utils.script_sleep(0.5)
+            if self.config.retirement['commons']:
                 Utils.touch_randomly(self.region['common_ship_filter'])
                 Utils.script_sleep(0.5)
-                continue
-            if self.config.retirement['rares'] and not Utils.find('retirement/button_sort_rare', 0.99):
-                Logger.log_debug("Retirement: Sorting rares")
+            if self.config.retirement['rares']:
                 Utils.touch_randomly(self.region['rare_ship_filter'])
                 Utils.script_sleep(0.5)
-                continue            
-            Logger.log_debug("Retirement: Confirming sort options")
-            self.sorted = True
+            
+            # check if correct options are enabled
+            # get the regions of enabled options
+            options = Utils.get_enabled_retirement_filters()
+            if len(options) == 0:
+                # if the list is empty it probably means that there was an ui update
+                # pausing and requesting for user confirmation
+                Logger.log_error("No options detected. User's input required.")
+                input("Manually fix sorting options. Press Enter to continue...")
+                self.sorted = True
+            else:
+                retirements = (self.config.retirement['commons'], self.config.retirement['rares'])
+                checks = [False, False]
+                for option in options:
+                    # tolerance is set to 25 since the regions chosen for tapping are smaller than the actual ones
+                    if self.config.retirement['commons'] and self.region['common_ship_filter'].equal_approximated(option, 25):
+                        Logger.log_debug("Retirement: Sorting commons")
+                        checks[0] = True
+                    if self.config.retirement['rares'] and self.region['rare_ship_filter'].equal_approximated(option, 25):
+                        Logger.log_debug("Retirement: Sorting rares")
+                        checks[1] = True
+                if retirements == tuple(checks) and len(options) <= 2:
+                    Logger.log_debug("Retirement: Sorting options confirmed")
+                    self.sorted = True
             Utils.touch_randomly(self.region['confirm_filter_button'])
             Utils.script_sleep(1)
             

--- a/util/utils.py
+++ b/util/utils.py
@@ -72,7 +72,7 @@ class Utils(object):
     @staticmethod
     def update_screen():
         """Uses ADB to pull a screenshot of the device and then read it via CV2
-        and then returns the read image.
+        and then returns the read image. The image is in a grayscale format.
 
         Returns:
             image: A CV2 image object containing the current device screen.
@@ -97,6 +97,22 @@ class Utils(object):
         else:
             cls.script_sleep(time)
         cls.update_screen()
+
+    @staticmethod
+    def get_color_screen():
+        """Uses ADB to pull a screenshot of the device and then read it via CV2
+        and then returns the read image. The image is in a BGR format.
+
+        Returns:
+            image: A CV2 image object containing the current device screen.
+        """
+        color_screen = None
+        while color_screen is None:
+            if Adb.legacy:
+                color_screen = cv2.imdecode(numpy.fromstring(Adb.exec_out(r"screencap -p | sed s/\r\n/\n/"),dtype=numpy.uint8), 1)
+            else:
+                color_screen = cv2.imdecode(numpy.fromstring(Adb.exec_out('screencap -p'), dtype=numpy.uint8), 1)
+        return color_screen
 
     @staticmethod
     def read_numbers(x, y, w, h, max_digits=5):
@@ -328,13 +344,7 @@ class Utils(object):
 
     @classmethod
     def find_siren_elites(cls):
-        # XXX: This should be pulled into its own method at some point.
-        color_screen = None
-        while color_screen is None:
-            if Adb.legacy:
-                color_screen = cv2.imdecode(numpy.fromstring(Adb.exec_out(r"screencap -p | sed s/\r\n/\n/"),dtype=numpy.uint8), 1)
-            else:
-                color_screen = cv2.imdecode(numpy.fromstring(Adb.exec_out('screencap -p'), dtype=numpy.uint8), 1)
+        color_screen = cls.get_color_screen()
         
         image = cv2.cvtColor(color_screen, cv2.COLOR_BGR2HSV)
         

--- a/util/utils.py
+++ b/util/utils.py
@@ -26,6 +26,23 @@ class Region(object):
         self.w = w
         self.h = h
 
+    def equal_approximated(self, region, tolerance=15):
+        """Compares this region to the one received and establishes if they are the same
+        region tolerating a difference in pixels up to the one prescribed by tolerance.
+
+        Args:
+            region (Region): The region to compare to.
+            tolerance (int, optional): Defaults to 15.
+                Highest difference of pixels tolerated to consider the two Regions equal.
+                If set to 0, the method becomes a "strict" equal.
+        """
+        valid_x = (self.x - tolerance, self.x + tolerance)
+        valid_y = (self.y - tolerance, self.y + tolerance)
+        valid_w = (self.w - tolerance, self.w + tolerance)
+        valid_h = (self.h - tolerance, self.h + tolerance)
+        return (valid_x[0] <= region.x <= valid_x[1]  and valid_y[0] <= region.y <= valid_y[1] and
+            valid_w[0] <= region.w <= valid_w[1] and valid_h[0] <= region.h <= valid_h[1])
+
 screen = None
 last_ocr = ''
 


### PR DESCRIPTION
Changes:
- Added `get_color_screen` method to Utils (refactored from `find_siren_elites`).
- Defined a method to compare Region objects.
- Changed the way to check the correctness of the retirement's filters selected. 
Instead of using template matching, it's now using color detection: script detects all blue rectangles of interest with `get_enabled_retirement_filters` method and checks if they are the expected ones. If it doesn't find anything, the script pauses and asks for user's input.

