### PR TITLE
Focus on mystery nodes

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -16,6 +16,8 @@ BossFleet: False
 OilLimit: 1000
 RetireCycle: 2
 RetreatAfter: 0
+IgnoreMysteryNodes: False
+FocusOnMysteryNodes: False
 HideSubsHuntingRange: False
 SmallBossIcon: False
 SirenElites: False

--- a/util/config.py
+++ b/util/config.py
@@ -103,6 +103,8 @@ class Config(object):
         self.combat['oil_limit'] = int(config.get('Combat', 'OilLimit'))
         self.combat['retire_cycle'] = int(config.get('Combat', 'RetireCycle'))
         self.combat['retreat_after'] = int(config.get('Combat', 'RetreatAfter'))
+        self.combat['ignore_mystery_nodes'] = config.getboolean('Combat', 'IgnoreMysteryNodes')
+        self.combat['focus_on_mystery_nodes'] = config.getboolean('Combat', 'FocusOnMysteryNodes')
         self.combat['hide_subs_hunting_range'] = config.getboolean('Combat', 'HideSubsHuntingRange')
         self.combat['small_boss_icon'] = config.getboolean('Combat', 'SmallBossIcon')
         self.combat['siren_elites'] = config.getboolean('Combat', 'SirenElites')

--- a/util/utils.py
+++ b/util/utils.py
@@ -176,6 +176,19 @@ class Utils(object):
 
         return regions
 
+    @classmethod
+    def show_on_screen(cls, coordinates):
+        """ Shows the position of the received coordinates on a screenshot
+            through green dots. It pauses the script. Useful for debugging.
+        """
+        color_screen = cls.get_color_screen()
+        for coords in coordinates:
+            cv2.circle(color_screen, tuple(coords), 5, (0, 255, 0), -1)
+        cv2.imshow("targets", color_screen)
+        cv2.waitKey(0)
+        cv2.destroyAllWindows()
+        return        
+
     @staticmethod
     def read_numbers(x, y, w, h, max_digits=5):
         """ Method to ocr numbers.


### PR DESCRIPTION
_Addressing issue #38_
Two new options have been added to the configuration file to better customize the bot's behavior related to mystery nodes:
- `IgnoreMysteryNodes` option enables/disables the search for mystery nodes, i.e. if set to `True` the bot skips the search for said nodes, but if they are on its path to a target they still get picked up;
- `FocusOnMysteryNodes` option forces the bot to first target mystery nodes (if set to `True`) even if there are enemies closer to the clearing fleet.