### PR TITLE
Improving enhancement module

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -29,8 +29,11 @@ SkillBookTier: 2
 
 [Modules]
 Commissions: False
-Enhancement: False
 Missions: False
+
+[Enhancement]
+Enabled: False
+SingleEnhancement: False
 
 [Retirement]
 Enabled: False

--- a/modules/enhancement.py
+++ b/modules/enhancement.py
@@ -13,11 +13,17 @@ class EnhancementModule(object):
         """
         self.config = config
         self.stats = stats
+        self.sorted = False
+        self.fill_count = 0
         self.last_enhance = 0
         self.region = {
             'button_favorite': Region(1014, 19, 170, 42),
             'button_go_back': Region(54, 57, 67, 67),
             'dock_tab': Region(297, 1015, 155, 40),
+            'sort_filters_button': Region(1655, 14, 130, 51),
+            'extra_all_ship_filter': Region(435, 779, 190, 45),
+            'extra_enhanceable_ship_filter': Region(1143, 779, 190, 45),
+            'confirm_filter_button': Region(1090, 933, 220, 60),
             'first_favorite_ship': Region(209, 209, 80, 120),
             'fill_button': Region(1467, 917, 140, 38),
             'enhance_tab_normal_ship': Region(31, 188, 91, 91),
@@ -34,6 +40,7 @@ class EnhancementModule(object):
         """
         if self.need_to_enhance:
             self.last_enhance = self.stats.combat_done
+            self.fill_count = 0
             Logger.log_msg("Opening dock to enhance ship.")
 
             while True:
@@ -41,19 +48,56 @@ class EnhancementModule(object):
 
                 if Utils.find("menu/button_battle"):
                     Utils.touch_randomly(self.region['dock_tab'])
-                    Utils.script_sleep(1)
+                    Utils.script_sleep(2)
                     continue
+                if Utils.find("retirement/empty"):
+                    Logger.log_msg("No ships left to enhance.")
+                    Utils.touch_randomly(self.region['button_go_back'])
+                    return
                 if Utils.find("enhancement/button_favorite", 0.99):
                     self.enhance_ship()
+                    Utils.script_sleep(1)
                     Utils.touch_randomly(self.region['button_favorite'])
+                    Utils.script_sleep(0.5)
                     Utils.touch_randomly(self.region['button_go_back'])
                     return
                 if Utils.find("menu/dock"):
                     Utils.touch_randomly(self.region['button_favorite'])
+                    Utils.script_sleep(1)
+                    self.set_sort()
                     continue
                 else:
                     Utils.touch_randomly(self.region['button_go_back'])
                     Utils.script_sleep(2)
+    
+    def set_sort(self):
+        """Method which sets the correct filters for enhancement, i.e. 'Enhanceable' option.
+        """
+        while not self.sorted:
+            Logger.log_debug("Enhancement: Opening sorting menu.")
+            Utils.touch_randomly(self.region['sort_filters_button'])
+            Utils.script_sleep(0.5)
+            # Touch the All button to clear any current filter
+            Utils.touch_randomly(self.region['extra_all_ship_filter'])
+            Utils.script_sleep(0.5)
+            # Touch the Enhanceable button
+            Utils.touch_randomly(self.region['extra_enhanceable_ship_filter'])
+            Utils.script_sleep(0.5)
+            
+            # check if correct options are enabled
+            # get the regions of enabled options
+            options = Utils.get_enabled_ship_filters(filter_category="extra")
+            if len(options) == 1 and self.region['extra_enhanceable_ship_filter'].equal_approximated(options[0], 25):
+                Logger.log_debug("Enhancement: Sorting options confirmed")
+                self.sorted = True
+            elif len(options) == 0:
+                # if the list is empty it probably means that there was an ui update
+                # pausing and requesting for user confirmation
+                Logger.log_error("No options detected. User's input required.")
+                input("Manually fix sorting options. Press Enter to continue...")
+                self.sorted = True
+            Utils.touch_randomly(self.region['confirm_filter_button'])
+            Utils.script_sleep(1)
 
     def enhance_ship(self):
         """
@@ -69,16 +113,19 @@ class EnhancementModule(object):
 
             if Utils.find("enhancement/menu_enhance"):
                 Logger.log_debug("Filling with ships.")
+                self.fill_count += 1
                 #taps the "fill" button
                 Utils.touch_randomly(self.region['fill_button'])
                 Utils.update_screen()
-            if Utils.find("enhancement/alert_no_items", 0.85):
+            if Utils.find("enhancement/alert_no_items", 0.85) or self.fill_count >= 10:
                 Logger.log_warning("Not enough ships to enhance.")
                 break
             if Utils.find("enhancement/menu_level", 0.8):
                 self.handle_retirement()
-                Logger.log_msg("Successfully finished enhancing.")
-                break
+                Logger.log_msg("Successfully enhanced ship.")
+                if self.config.enhancement['single_enhancement'] or self.fill_count >= 10:
+                    break
+                continue
             if Utils.find("enhancement/menu_details"):
                 Logger.log_debug("Opening enhance menu.")
                 if not Utils.find("enhancement/menu_retrofit", 0.9):

--- a/modules/retirement.py
+++ b/modules/retirement.py
@@ -99,7 +99,7 @@ class RetirementModule(object):
             
             # check if correct options are enabled
             # get the regions of enabled options
-            options = Utils.get_enabled_retirement_filters()
+            options = Utils.get_enabled_ship_filters()
             if len(options) == 0:
                 # if the list is empty it probably means that there was an ui update
                 # pausing and requesting for user confirmation

--- a/util/config.py
+++ b/util/config.py
@@ -50,8 +50,10 @@ class Config(object):
             self._read_headquarters(config)
 
         self.commissions['enabled'] = config.getboolean('Modules', 'Commissions')
-        self.enhancement['enabled'] = config.getboolean('Modules', 'Enhancement')
         self.missions['enabled'] = config.getboolean('Modules', 'Missions')
+
+        if config.getboolean('Enhancement', 'Enabled'):
+            self._read_enhancement(config)
         
         if 'Retirement' in config:
             # New retirement settings
@@ -84,7 +86,7 @@ class Config(object):
                 self.changed = True
 
     def _read_updates(self, config):
-        """Method to parse the Combat settings of the passed in config.
+        """Method to parse the Updates settings of the passed in config.
         Args:
             config (ConfigParser): ConfigParser instance
         """
@@ -118,6 +120,14 @@ class Config(object):
         self.academy['enabled'] = config.getboolean('Headquarters', 'Academy')
         if self.academy['enabled']:
             self.academy['skill_book_tier'] = int(config.get('Headquarters', 'SkillBookTier'))
+
+    def _read_enhancement(self, config):
+        """Method to parse the Enhancement settings of the passed in config.
+        Args:
+            config (ConfigParser): ConfigParser instance
+        """
+        self.enhancement['enabled'] = True
+        self.enhancement['single_enhancement'] = config.getboolean('Enhancement', 'SingleEnhancement')
 
     def _read_event(self, config):
         """Method to parse the Event settings of the passed in config.

--- a/util/utils.py
+++ b/util/utils.py
@@ -132,8 +132,8 @@ class Utils(object):
         return color_screen
 
     @classmethod
-    def get_enabled_retirement_filters(cls):
-        """Method which returns the regions of all the options enabled in the retirement's sorting filter.
+    def get_enabled_ship_filters(cls, filter_category="rarity"):
+        """Method which returns the regions of all the options enabled for the current sorting filter.
 
         Returns:
             regions: a list containing the Region objects detected.
@@ -142,7 +142,10 @@ class Utils(object):
         
         # mask area of no interest, effectively creating a roi
         roi = numpy.full((image.shape[0], image.shape[1]), 0, dtype=numpy.uint8)
-        cv2.rectangle(roi, (410, 647), (1835, 737), color=(255,255,255), thickness=-1)
+        if filter_category == "rarity":
+            cv2.rectangle(roi, (410, 647), (1835, 737), color=(255,255,255), thickness=-1)
+        elif filter_category == "extra":
+            cv2.rectangle(roi, (410, 758), (1835, 847), color=(255,255,255), thickness=-1)
         
         # preparing the ends of the interval of blue colors allowed, BGR format
         lower_blue = numpy.array([132, 97, 66], dtype=numpy.uint8)
@@ -157,7 +160,8 @@ class Utils(object):
         # obtain countours, needed to calculate the rectangles' positions
         cnts = cv2.findContours(result, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
         cnts = grab_contours(cnts)
-
+        # filter regions with a contour area inferior to 190x45=8550 (i.e. not a sorting option)
+        cnts = list(filter(lambda x: cv2.contourArea(x) > 8550, cnts))
         # loop over the contours and extract regions
         regions = []
         for c in cnts:


### PR DESCRIPTION
Changes:
- Repurposed `get_enabled_retirement_filters` (now `get_enabled_ship_filters`) to detect other categories of sorting menu.
- Created a separate section for enhancement in configuration file.
- Enhancement module now uses the new 'Enhanceable' filter: it now enhances favorite ships which are enhanceable, so if a ship can't be further enhanced, it no longer appears in the selection screen and the bot can target the next one.
- The enhancement procedure is now looped: the bot keeps enhancing the selected ship until there are no more materials or a number of enhancement attempted is reached. This behavior can be disabled (i.e. do only one enhancement) with the new option in the configuration file.